### PR TITLE
fix: Add camera and splash-screen plugins to the template

### DIFF
--- a/assets/app-template/package.json
+++ b/assets/app-template/package.json
@@ -11,7 +11,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@capacitor/core": "{{ CAPACITOR_VERSION }}"
+    "@capacitor/core": "{{ CAPACITOR_VERSION }}",
+    "@capacitor/camera": "latest",
+    "@capacitor/splash-screen": "latest"
   },
   "devDependencies": {
     "@capacitor/cli": "{{ CAPACITOR_VERSION }}"


### PR DESCRIPTION
The app includes code for splash-screen and camera, but the plugins are not installed