### PR TITLE
fix: Use latest instead of next as cap version

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -29,7 +29,7 @@ export const extractTemplate = async (
 
 export const applyTemplate = async (p: string): Promise<void> => {
   const contents = await readFile(p, { encoding: 'utf8' });
-  const result = Mustache.render(contents, { CAPACITOR_VERSION: 'next' });
+  const result = Mustache.render(contents, { CAPACITOR_VERSION: 'latest' });
 
   await writeFile(p, result, { encoding: 'utf8' });
 };


### PR DESCRIPTION
closes https://github.com/ionic-team/create-capacitor-app/issues/7