### PR TITLE
chore: remove Capacitor 2-3 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 Create a minimal (no JS framework) Capacitor app.
 
-> ### :rotating_light: This tool is for Capacitor 3, which is in active development :rotating_light:
->
-> To create minimal Capacitor 2 apps, use `npx @capacitor/cli create`. Follow Capacitor 3 development in [this issue](https://github.com/ionic-team/capacitor/issues/3133).
-
 ## Usage
 
 ```


### PR DESCRIPTION
Now create-capacitor-app creates a Capacitor 4 app, so better remove the "Capacitor 3" note. I won't replace the version with 4 because we would need to update it next year. 
Also people shouldn't be creating capacitor 2 apps anymore, so remove that part too.