### PR TITLE
chore: Remove running with serve text

### DIFF
--- a/assets/app-template/README.md
+++ b/assets/app-template/README.md
@@ -5,8 +5,6 @@ and comes with a very minimal shell for building an app.
 
 ### Running this example
 
-To run the provided example, you can use [serve](https://www.npmjs.com/package/serve):
-
 ```bash
 npm start
 ```

--- a/assets/app-template/README.md
+++ b/assets/app-template/README.md
@@ -5,6 +5,8 @@ and comes with a very minimal shell for building an app.
 
 ### Running this example
 
+To run the provided example, you can use `npm start` command.
+
 ```bash
 npm start
 ```


### PR DESCRIPTION
remove the text about serve since users can use npm start instead