### PR TITLE
feat: Update vite to latest

### DIFF
--- a/assets/app-template/package.json
+++ b/assets/app-template/package.json
@@ -2,7 +2,7 @@
   "name": "capacitor-app",
   "version": "1.0.0",
   "description": "An Amazing Capacitor App",
-  "main": "index.js",
+  "type": "module",
   "keywords": [
     "capacitor",
     "mobile"
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "{{ CAPACITOR_VERSION }}",
-    "vite": "^2.9.13"
+    "vite": "^5.4.2"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
Update vite from 2 to 5 on the generated app.
Remove unused `"main": "index.js",`.
Add `"type": "module",` to fix vite 5 deprecation warning.