### PR TITLE
chore: don't hide splash automatically

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export const createConfigFile = async ({ name: appName, dir, 'app-id': appId }: 
     webDir: 'dist',
     plugins: {
       SplashScreen: {
-        launchShowDuration: 0,
+        launchAutoHide: false,
       },
     },
   };


### PR DESCRIPTION
At the moment we install the splash screen plugin but it's not being used because the `launchShowDuration` is being set to 0 by default. We have a `SplashScreen.hide();` call that is not doing anything since the splash screen is not being shown.

So replace the `launchShowDuration: 0,` with `launchAutoHide: false,` so the splash screen is displayed and `SplashScreen.hide();` hides it.

Alternatively, we can just uninstall the splash screen plugin and remove the code for it.